### PR TITLE
Fix run.sh test path

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ run_all_tests() {
   cd /app
   python tools/install_local_wheel.py --driver nitclk >/dev/null 2>&1 || true
   set +e
-  pytest -vv generated/ || true
+  pytest -vv generated/*/*/unit_tests || true
   set -e
 }
 


### PR DESCRIPTION
## Summary
- point test runner to the `unit_tests` directories

## Testing
- `./run.sh` *(fails: `/app` missing)*